### PR TITLE
chore: kotlin compiler - allWarningsAsErrors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,7 @@ tasks.getByName<Test>("test") {
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
     kotlinOptions.javaParameters = true
+    kotlinOptions.allWarningsAsErrors = true
 }
 
 /*

--- a/src/main/kotlin/com/asyncapi/plugin/core/AsyncAPISchemaGenerator.kt
+++ b/src/main/kotlin/com/asyncapi/plugin/core/AsyncAPISchemaGenerator.kt
@@ -93,7 +93,7 @@ abstract class AsyncAPISchemaGenerator(
         )
 
         resolveLogger().info(Messages.get("generation.generation-strategy.checking"))
-        return when(schemaFileFormat.toLowerCase()) {
+        return when(schemaFileFormat.lowercase()) {
             "json" -> {
                 resolveLogger().info(Messages.get("generation.generation-strategy.success", "json"))
                 JsonGenerationStrategy(generationSettings)


### PR DESCRIPTION
- 'toLowerCase(): String' is deprecated. Use lowercase() instead.
- allWarningsAsErrors was enabled